### PR TITLE
Stricter default filter

### DIFF
--- a/config.json
+++ b/config.json
@@ -9,7 +9,7 @@
   "scan_delay": 60000,
 
   "banned_words": [
-    "Robux", "Free", "Scam", "Gamepass", "Builderman", "Website", "Verify", "Download", "Visit", "Pass"
+    "Robux", "Free", "Scam", "Gamepass", "Builderman", "Website", "Verify", "Download", "Visit", "Pass", "Bux", "Claim", "Proceed", "Eligible", "Link", "Vip", "Info"
   ],
   "target_level": 5,
   "op_ranks": 250,


### PR DESCRIPTION
Since bots have now been advanced farther, with more words of different types, the default filter should be able to scan for these as well, to prevent more advanced bots.